### PR TITLE
interp.c: fix bug: fread never returns -1

### DIFF
--- a/interp.c
+++ b/interp.c
@@ -26,13 +26,13 @@ read_file(const char *filename, char **buffer, size_t *len)
     }
 
     fseek(f, 0, SEEK_END);
-    ssize_t length = ftell(f);
+    long length = ftell(f);
     fseek(f, 0, SEEK_SET);
     *buffer = malloc(length);
     if (!*buffer)
         return 1;
 
-    if (fread(*buffer, 1, length, f) == -1) {
+    if (fread(*buffer, 1, length, f) != (size_t)length) {
         free(*buffer);
         return 1;
     }


### PR DESCRIPTION
I am not sure how to test this, but I'm pretty sure that fread will not return "-1" -- unless you have a VERY LARGE file:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/fread.html

Also, I believe that ftell returns a long, not a ssize_t:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/ftell.html